### PR TITLE
Update versions file to require TF 1.x and pin to AWS v4 provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }


### PR DESCRIPTION
Currently the module uses aws_subnet_ids which has been deprecated in v5. Module currently doesn't state any version, so this has been set to v4 to make it resume working.
Increased the Terraform version as well for good measure!